### PR TITLE
Default to `0.0.0.0` host

### DIFF
--- a/cmd/minecraftrouter.go
+++ b/cmd/minecraftrouter.go
@@ -23,7 +23,7 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "host",
-				Value:       "127.0.0.1",
+				Value:       "0.0.0.0",
 				Usage:       "bind listener socket to this host",
 				Destination: &host,
 				EnvVars:     []string{"MINECRAFT_ROUTER_HOST"},


### PR DESCRIPTION
`0.0.0.0` is a more likely desired default, rather than `127.0.0.1`