### PR TITLE
Standardize format for log messages and context keys

### DIFF
--- a/cmd/minecraftrouter.go
+++ b/cmd/minecraftrouter.go
@@ -106,6 +106,6 @@ func main() {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal().
 			Err(err).
-			Msg("error while running application")
+			Msg("Error while running application")
 	}
 }

--- a/pkg/resolver/api_resolver.go
+++ b/pkg/resolver/api_resolver.go
@@ -30,7 +30,7 @@ func (a ApiResolver) ResolveHostname(hostname string) (string, bool) {
 }
 
 func (a ApiResolver) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("apiUrl", a.apiUrl)
+	e.Str("ApiUrl", a.apiUrl)
 }
 
 func NewApiResolver(apiUrl string) ApiResolver {

--- a/pkg/resolver/json_resolver.go
+++ b/pkg/resolver/json_resolver.go
@@ -18,7 +18,7 @@ func (j JsonResolver) ResolveHostname(hostname string) (string, bool) {
 }
 
 func (j JsonResolver) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("filepath", j.filepath)
+	e.Str("Filepath", j.filepath)
 }
 
 func NewJsonResolver(filepath string) (*JsonResolver, error) {

--- a/pkg/router.go
+++ b/pkg/router.go
@@ -152,7 +152,7 @@ func (r Router) handleConnection(client net.Conn) {
 		log.Error().
 			Err(err).
 			Stringer("Client", client.RemoteAddr()).
-			Stringer("server", server.RemoteAddr()).
+			Stringer("Server", server.RemoteAddr()).
 			Msg("Unable to create proxy protocol header. Closing connection.")
 		client.Close()
 		return
@@ -162,7 +162,7 @@ func (r Router) handleConnection(client net.Conn) {
 	if err != nil {
 		log.Error().
 			Err(err).
-			Stringer("server", server.RemoteAddr()).
+			Stringer("Server", server.RemoteAddr()).
 			Msg("Unable to write proxy protocol header to server. Closing connections.")
 		server.Close()
 		client.Close()
@@ -173,7 +173,7 @@ func (r Router) handleConnection(client net.Conn) {
 	if err != nil {
 		log.Error().
 			Err(err).
-			Stringer("server", server.RemoteAddr()).
+			Stringer("Server", server.RemoteAddr()).
 			Msg("Unable to write handshake packet to server. Closing connections.")
 		server.Close()
 		client.Close()


### PR DESCRIPTION
Capitalize first letter of each log message, and use PascalCasing for context keys