### PR TITLE
add authenticated mc admin api routing configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,5 +2,6 @@
 MINECRAFT_ADMIN_SERVICE_ACCOUNT_ID=your-uuid-here
 MINECRAFT_ADMIN_SERVICE_ACCOUNT_SECRET=your-secret-here
 
-# Lookup URL can be set as env var or CLI option
-# MINECRAFT_ROUTER_LOOKUP=https://mcapi.abandontech.cloud/
+# Use one of the following (mutually exclusive):
+# ROUTER_CONFIG_FILE=routing.json
+# ROUTER_CONFIG_URL=https://mcapi.abandontech.cloud/

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
 # MinecraftAdmin API credentials (required when using API resolver)
 MINECRAFT_ADMIN_SERVICE_ACCOUNT_ID=your-uuid-here
 MINECRAFT_ADMIN_SERVICE_ACCOUNT_SECRET=your-secret-here
+
+# Lookup URL can be set as env var or CLI option
+# MINECRAFT_ROUTER_LOOKUP=https://mcapi.abandontech.cloud/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# MinecraftAdmin API credentials (required when using API resolver)
+MINECRAFT_ADMIN_SERVICE_ACCOUNT_ID=your-uuid-here
+MINECRAFT_ADMIN_SERVICE_ACCOUNT_SECRET=your-secret-here

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data
 
 .idea
 .direnv
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN go build cmd/minecraftrouter.go \
 
 FROM scratch
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /out/minecraftrouter /usr/local/bin/
 
 EXPOSE 25565

--- a/cmd/minecraftrouter.go
+++ b/cmd/minecraftrouter.go
@@ -103,9 +103,7 @@ func main() {
 
 				if accountID == "" || secret == "" {
 					log.Fatal().
-						Msg("MINECRAFT_ADMIN_SERVICE_ACCOUNT_ID and MINECRAFT_ADMIN_SERVICE_ACCOUNT_SECRET must be set when using the API resolver. " +
-							"For Docker deployments, set these in a .env file alongside docker-compose.yml. " +
-							"For local development, export them in your shell")
+						Msg("MINECRAFT_ADMIN_SERVICE_ACCOUNT_ID and MINECRAFT_ADMIN_SERVICE_ACCOUNT_SECRET env vars must be set when using the API resolver.")
 				}
 
 				pollInterval := ctx.Duration("poll-interval")

--- a/cmd/minecraftrouter.go
+++ b/cmd/minecraftrouter.go
@@ -28,14 +28,14 @@ func main() {
 				Value:       "0.0.0.0",
 				Usage:       "bind listener socket to this host",
 				Destination: &host,
-				EnvVars:     []string{"MINECRAFT_ROUTER_HOST"},
+				EnvVars:     []string{"ROUTER_HOST"},
 			},
 			&cli.UintFlag{
 				Name:        "port",
 				Value:       25565,
 				Usage:       "bind listener socket to this port",
 				Destination: &port,
-				EnvVars:     []string{"MINECRAFT_ROUTER_PORT"},
+				EnvVars:     []string{"ROUTER_PORT"},
 			},
 			&cli.StringFlag{
 				Name:        "file",
@@ -69,7 +69,7 @@ func main() {
 			&cli.BoolFlag{
 				Name:    "proxy-protocol",
 				Usage:   "enable proxy protocol",
-				EnvVars: []string{"MINECRAFT_ROUTER_PROXY_PROTOCOL"},
+				EnvVars: []string{"ROUTER_PROXY_PROTOCOL"},
 				Value:   false,
 			},
 		},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-version: "3"
-
-
 services:
 
   # minecraft:
@@ -18,7 +15,6 @@ services:
     image: "ghcr.io/abandontech/minecraftrouter:local"
     env_file:
       - .env
-    restart: unless-stopped
     volumes:
       - "./routing.json:/routing.json"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,19 +3,23 @@ version: "3"
 
 services:
 
-  minecraft:
-    image: "itzg/minecraft-server"
-    environment:
-      EULA: TRUE
-      TYPE: "PAPER"
-    volumes:
-      - "./data:/data"
-    ports:
-      - "25566:25565"
+  # minecraft:
+  #   image: "itzg/minecraft-server"
+  #   environment:
+  #     EULA: TRUE
+  #     TYPE: "PAPER"
+  #   volumes:
+  #     - "./data:/data"
+  #   ports:
+  #     - "25566:25565"
 
   minecraftrouter:
     build: .
     image: "ghcr.io/abandontech/minecraftrouter:local"
+    env_file:
+      - .env
     restart: unless-stopped
+    volumes:
+      - "./routing.json:/routing.json"
     ports:
       - "25565:25565"

--- a/pkg/resolver/api_resolver.go
+++ b/pkg/resolver/api_resolver.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -152,11 +153,10 @@ func (a *ApiResolver) MarshalZerologObject(e *zerolog.Event) {
 }
 
 func NewApiResolver(ctx context.Context, apiURL, accountID, secret string, pollInterval time.Duration) (*ApiResolver, error) {
-	parsed, err := url.Parse(apiURL)
-	if err != nil {
+	if _, err := url.Parse(apiURL); err != nil {
 		return nil, fmt.Errorf("parse API URL: %w", err)
 	}
-	baseURL := parsed.Scheme + "://" + parsed.Host
+	baseURL := strings.TrimRight(apiURL, "/")
 
 	resolver := &ApiResolver{
 		baseURL:   baseURL,

--- a/pkg/resolver/api_resolver.go
+++ b/pkg/resolver/api_resolver.go
@@ -68,9 +68,7 @@ func (a *ApiResolver) login(ctx context.Context) error {
 		return fmt.Errorf("decode login response: %w", err)
 	}
 
-	a.mu.Lock()
 	a.token = result.Token
-	a.mu.Unlock()
 
 	log.Debug().Msg("Successfully authenticated with MinecraftAdmin API")
 	return nil
@@ -82,9 +80,7 @@ func (a *ApiResolver) fetchMapping(ctx context.Context) error {
 		return fmt.Errorf("create mapping request: %w", err)
 	}
 
-	a.mu.RLock()
 	token := a.token
-	a.mu.RUnlock()
 
 	req.Header.Set("Authorization", "Bearer "+token)
 

--- a/pkg/resolver/api_resolver.go
+++ b/pkg/resolver/api_resolver.go
@@ -1,40 +1,182 @@
 package resolver
 
 import (
+	"bytes"
+	"context"
 	"encoding/json"
-	"github.com/rs/zerolog"
-	"log"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
+var errUnauthorized = errors.New("unauthorized")
+
 type ApiResolver struct {
-	apiUrl string
+	baseURL    string
+	accountID  string
+	secret     string
+	mu         sync.RWMutex
+	routes     map[string]string
+	token      string
+	httpClient *http.Client
 }
 
-func (a ApiResolver) ResolveHostname(hostname string) (string, bool) {
-	resp, err := http.Get(a.apiUrl)
+func (a *ApiResolver) login(ctx context.Context) error {
+	body, err := json.Marshal(map[string]string{
+		"user_account_id": a.accountID,
+		"secret":          a.secret,
+	})
 	if err != nil {
-		log.Fatal(err, "Unable to request from api")
+		return fmt.Errorf("marshal login request: %w", err)
 	}
 
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.baseURL+"/service/login", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("create login request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("login request: %w", err)
+	}
 	defer resp.Body.Close()
-	var data map[string]string
 
-	err = json.NewDecoder(resp.Body).Decode(&data)
-	if err != nil {
-		log.Fatal(err, "Unable to decode response from api")
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("login failed: invalid credentials (401)")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("login failed: unexpected status %d", resp.StatusCode)
 	}
 
-	val, ok := data[hostname]
+	var result struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return fmt.Errorf("decode login response: %w", err)
+	}
+
+	a.mu.Lock()
+	a.token = result.Token
+	a.mu.Unlock()
+
+	log.Debug().Msg("Successfully authenticated with MinecraftAdmin API")
+	return nil
+}
+
+func (a *ApiResolver) fetchMapping(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.baseURL+"/service/mapping", nil)
+	if err != nil {
+		return fmt.Errorf("create mapping request: %w", err)
+	}
+
+	a.mu.RLock()
+	token := a.token
+	a.mu.RUnlock()
+
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("mapping request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		return errUnauthorized
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("mapping fetch failed: unexpected status %d", resp.StatusCode)
+	}
+
+	var routes map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&routes); err != nil {
+		return fmt.Errorf("decode mapping response: %w", err)
+	}
+
+	a.mu.Lock()
+	a.routes = routes
+	a.mu.Unlock()
+
+	log.Debug().Int("RouteCount", len(routes)).Msg("Routing cache refreshed")
+	return nil
+}
+
+func (a *ApiResolver) refresh(ctx context.Context) error {
+	err := a.fetchMapping(ctx)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, errUnauthorized) {
+		return err
+	}
+
+	log.Debug().Msg("Received 401 from mapping endpoint, re-authenticating")
+	if err := a.login(ctx); err != nil {
+		return fmt.Errorf("re-authentication failed: %w", err)
+	}
+	return a.fetchMapping(ctx)
+}
+
+func (a *ApiResolver) poll(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := a.refresh(ctx); err != nil {
+				log.Warn().Err(err).Msg("Failed to refresh routing cache, keeping last-known-good cache")
+			}
+		}
+	}
+}
+
+func (a *ApiResolver) ResolveHostname(hostname string) (string, bool) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	val, ok := a.routes[hostname]
 	return val, ok
 }
 
-func (a ApiResolver) MarshalZerologObject(e *zerolog.Event) {
-	e.Str("ApiUrl", a.apiUrl)
+func (a *ApiResolver) MarshalZerologObject(e *zerolog.Event) {
+	e.Str("ApiBaseUrl", a.baseURL)
 }
 
-func NewApiResolver(apiUrl string) ApiResolver {
-	return ApiResolver{
-		apiUrl: apiUrl,
+func NewApiResolver(ctx context.Context, apiURL, accountID, secret string, pollInterval time.Duration) (*ApiResolver, error) {
+	parsed, err := url.Parse(apiURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse API URL: %w", err)
 	}
+	baseURL := parsed.Scheme + "://" + parsed.Host
+
+	resolver := &ApiResolver{
+		baseURL:   baseURL,
+		accountID: accountID,
+		secret:    secret,
+		routes:    make(map[string]string),
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+
+	if err := resolver.login(ctx); err != nil {
+		return nil, fmt.Errorf("initial authentication failed: %w", err)
+	}
+
+	if err := resolver.refresh(ctx); err != nil {
+		return nil, fmt.Errorf("initial mapping fetch failed: %w", err)
+	}
+
+	go resolver.poll(ctx, pollInterval)
+
+	return resolver, nil
 }

--- a/pkg/resolver/api_resolver.go
+++ b/pkg/resolver/api_resolver.go
@@ -49,7 +49,7 @@ func (a *ApiResolver) login(ctx context.Context) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized {
-		return fmt.Errorf("login failed: invalid credentials (401)")
+		return fmt.Errorf("login failed: unauthorized")
 	}
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("login failed: unexpected status %d", resp.StatusCode)


### PR DESCRIPTION
I have also removed support for generic APIs, this seems unnecessary as anyone can just load any file content into 
outing.json if they want the flexibility of using their own api.